### PR TITLE
不具合調整完了

### DIFF
--- a/app/controllers/pcomments_controller.rb
+++ b/app/controllers/pcomments_controller.rb
@@ -5,7 +5,7 @@ class PcommentsController < ApplicationController
     if @pcomment.save
       redirect_to practice_path(@practice)
     else
-      @pcomments=Pcomment.all
+      @pcomments=Pcomment.where(practice_id:@practice.id)
       render "practices/show"
     end
   end

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -10,7 +10,7 @@ class PracticesController < ApplicationController
 
   def show
     @pcomment=Pcomment.new
-    @pcomments=Pcomment.all
+    @pcomments=Pcomment.where(practice_id:@practice.id)
   end
 
   def new


### PR DESCRIPTION
# what
コントローラの設定で表示するコメントをどの投稿に対しても全コメントを表示していたため、投稿に紐づいたコメントのみ表示するように設定した。
# Why
どの投稿に対してのコメントかユーザが直感的にわかるようにするため
