### PR TITLE
新規投稿ページでのインクリメンタルサーチ機能

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -58,6 +58,12 @@ class PracticesController < ApplicationController
     @practices=Practice.includes(:liked_users).limit(5).sort{|a,b| b.liked_users.size <=> a.liked_users.size}
   end
 
+  def ptaglist
+    
+    return nil if params[:keyword] == ""
+    ptag = Ptag.where(['name LIKE ?', "%#{params[:keyword]}%"] )
+    render json:{ keyword: ptag }
+  end
 
   private
   def create_params

--- a/app/javascript/packs/ptag.js
+++ b/app/javascript/packs/ptag.js
@@ -1,0 +1,42 @@
+if (location.pathname.match("/new")||location.pathname.match("/edit")||location.pathname.match("practices")){
+  document.addEventListener("DOMContentLoaded", () => {
+    console.log("ok");
+    const inputElement = document.getElementById("practices_ptag_name");
+    inputElement.addEventListener("keyup", () => {
+      let keyword = document.getElementById("practices_ptag_name").value;
+      if(keyword.includes(',')){
+        keyword=keyword.substring(keyword.lastIndexOf(',')+1,keyword.length-1);
+        console.log(keyword);
+      }
+
+      const XHR = new XMLHttpRequest();
+      XHR.open("GET", `ptaglist/?keyword=${keyword}`, true);
+      XHR.responseType = "json";
+      XHR.send();
+      XHR.onload=()=>{
+        const searchResult = document.getElementById("search-result");
+        searchResult.innerHTML = "";
+        if (XHR.response) {
+          const tagName = XHR.response.keyword;
+          tagName.forEach((ptag) => {
+            const childElement = document.createElement("div");
+            childElement.setAttribute("class", "child");
+            childElement.setAttribute("id", ptag.id);
+            childElement.innerHTML = ptag.name;
+            searchResult.appendChild(childElement);
+            const clickElement = document.getElementById(ptag.id);
+  
+            clickElement.addEventListener("click", () => {
+              let tagForm= document.getElementById("practices_ptag_name") ;
+              tagForm.value=tagForm.value.substring(tagForm.value.lastIndexOf(",")+1,tagForm.value.lastIndexOf(",")-tagForm.length);
+              tagForm.value=tagForm.value.concat(clickElement.innerText);
+              console.log(clickElement.innerText);
+              console.log(`tagForm=${tagForm.value+clickElement.innerText}`);
+             
+            });
+          });
+        };
+      };
+    });
+  });
+};

--- a/app/javascript/packs/ptag.js
+++ b/app/javascript/packs/ptag.js
@@ -1,4 +1,4 @@
-if (location.pathname.match("/new")||location.pathname.match("/edit")||location.pathname.match("practices")){
+if (location.pathname.match("/new")/*||location.pathname.match("/edit")||location.pathname.match("practices")*/){
   document.addEventListener("DOMContentLoaded", () => {
     console.log("ok");
     const inputElement = document.getElementById("practices_ptag_name");

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -11,6 +11,7 @@
 @import "shared/tweet";
 @import "practices/index";
 @import "practices/show";
+@import "practices/new";
 @import "practices/rank";
 @import "practices/preview";
 @import "comments/comment";

--- a/app/javascript/stylesheets/practices/new.scss
+++ b/app/javascript/stylesheets/practices/new.scss
@@ -1,0 +1,5 @@
+.child {
+  border-bottom: #666 1px solid;
+  padding: 5px 11px;
+  background-color: white;
+}

--- a/app/views/practices/edit.html.erb
+++ b/app/views/practices/edit.html.erb
@@ -29,8 +29,10 @@
 
         <div class="form-group">
           <label>タグ</label>
-          <%= f.text_field :name, placeholder:",で区切ってください",class: "form-control" ,value: "#{@practices_ptag.name}"%>
+          <%= f.text_field :name, placeholder:",で区切ってください",class: "form-control" %>
         </div>
+         <div id="search-result"></div>
+       
 
         <div class="form-group">
           <label>練習風景の写真等（4枚までOK）</label><br>
@@ -51,3 +53,4 @@
 
 <%= javascript_pack_tag 'count' %>
 <%= javascript_pack_tag 'practice_preview' %>
+<%= javascript_pack_tag 'ptag' %>

--- a/app/views/practices/new.html.erb
+++ b/app/views/practices/new.html.erb
@@ -35,7 +35,7 @@
           <label>タグ</label>
           <%= f.text_field :name, placeholder:",で区切ってください",class: "form-control" %>
         </div>
-
+        <div id="search-result"></div>
      
 
         <div class="form-group">
@@ -58,4 +58,5 @@
 
 <%= javascript_pack_tag 'count' %>
 <%= javascript_pack_tag 'practice_preview' %>
+<%= javascript_pack_tag 'ptag' %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     resources :pcomments, only: [:create, :destroy]
     collection do
       get "rank"
+      get "ptaglist"
     end
   end
 


### PR DESCRIPTION
# What
インクリメンタルサーチ機能の実装

# Why
ユーザがタグを入力した時に、すでにあるタグの自動検索を行うため。

# 重要なお知らせ
本機能は編集ページ（practice/:id/edit）とrenderされたときのページでは機能しない。
原因究明を急ぐものの、現段階では他の機能実装の方が優先度が高いとして、いったん保留としている